### PR TITLE
Willnilges/devcade docs migration

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -99,6 +99,10 @@ def credits():
 def gamejam():
     return flask.render_template('gamejam.html')
 
+@app.route('/docs')
+def docs():
+    return flask.redirect('https://devcade-docs.csh.rit.edu')
+
 @app.errorhandler(Exception)
 def page404(e):
     eCode = 500

--- a/src/templates/header.html
+++ b/src/templates/header.html
@@ -65,7 +65,7 @@
         <div id="nav" class="dropped hidden">
           <div class="item"><a href="/">Home</a></div>
           <div class="item"><a href="/catalog">Games</a></div>
-          <div class="item"><a href="https://computersciencehouse.github.io/devcade-website/">Docs</a></div>
+          <div class="item"><a href="https://devcade-docs.csh.rit.edu">Docs</a></div>
           {% if current_user.is_authenticated %}
           <div class="item"><a href="/upload">Upload</a></div>
           <div class="item" id="account">

--- a/src/templates/header.html
+++ b/src/templates/header.html
@@ -65,7 +65,7 @@
         <div id="nav" class="dropped hidden">
           <div class="item"><a href="/">Home</a></div>
           <div class="item"><a href="/catalog">Games</a></div>
-          <div class="item"><a href="https://devcade-docs.csh.rit.edu">Docs</a></div>
+          <div class="item"><a href="/docs">Docs</a></div>
           {% if current_user.is_authenticated %}
           <div class="item"><a href="/upload">Upload</a></div>
           <div class="item" id="account">


### PR DESCRIPTION
Changes link on the top bar to the new documentation instance (https://devcade-docs.csh.rit.edu) and adds a `/docs` route that redirects there.

When we're through with merging all this, we should probably remove the github pages instance and delete the branch off of this repo.